### PR TITLE
Renaming things

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ python3 -m bio2zarr vcf2zarr explode tests/data/vcf/sample.vcf.gz tmp/sample.exp
 
 Then, (optionally) inspect this representation to get a feel for your dataset
 ```
-python3 -m bio2zarr vcf2zarr summarise tmp/sample.exploded
+python3 -m bio2zarr vcf2zarr inspec tmp/sample.exploded
 ```
 
 Then, (optionally) generate a conversion schema to describe the corresponding
 Zarr arrays:
 
 ```
-python3 -m bio2zarr vcf2zarr genspec tmp/sample.exploded > sample.schema.json
+python3 -m bio2zarr vcf2zarr mkschema tmp/sample.exploded > sample.schema.json
 ```
 
 View and edit the schema, deleting any columns you don't want.
@@ -44,7 +44,7 @@ View and edit the schema, deleting any columns you don't want.
 Finally, convert to Zarr
 
 ```
-python3 -m bio2zarr vcf2zarr to-zarr tmp/sample.exploded tmp/sample.zarr -s sample.schema.json
+python3 -m bio2zarr vcf2zarr encode tmp/sample.exploded tmp/sample.zarr -s sample.schema.json
 ```
 
 Use the ``-p, --worker-processes`` argument to control the number of workers used

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -46,32 +46,32 @@ def explode(vcfs, out_path, verbose, worker_processes, column_chunk_size):
 
 
 @click.command
-@click.argument("columnarised", type=click.Path())
+@click.argument("if_path", type=click.Path())
 @verbose
-def inspect(columnarised, verbose):
+def inspect(if_path, verbose):
     setup_logging(verbose)
-    data = vcf.inspect(columnarised)
+    data = vcf.inspect(if_path)
     click.echo(tabulate.tabulate(data, headers="keys"))
 
 
 @click.command
-@click.argument("columnarised", type=click.Path())
+@click.argument("if_path", type=click.Path())
 # @click.argument("specfile", type=click.Path())
-def genspec(columnarised):
+def genspec(if_path):
     stream = click.get_text_stream("stdout")
-    vcf.generate_spec(columnarised, stream)
+    vcf.generate_spec(if_path, stream)
 
 
 @click.command
-@click.argument("columnarised", type=click.Path())
+@click.argument("if_path", type=click.Path())
 @click.argument("zarr_path", type=click.Path())
 @verbose
 @click.option("-s", "--conversion-spec", default=None)
 @worker_processes
-def to_zarr(columnarised, zarr_path, verbose, conversion_spec, worker_processes):
+def to_zarr(if_path, zarr_path, verbose, conversion_spec, worker_processes):
     setup_logging(verbose)
     vcf.to_zarr(
-        columnarised,
+        if_path,
         zarr_path,
         conversion_spec,
         worker_processes=worker_processes,

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -85,15 +85,14 @@ def encode(if_path, zarr_path, verbose, schema, worker_processes):
 @worker_processes
 def convert_vcf(vcfs, out_path, verbose, worker_processes):
     setup_logging(verbose)
-    vcf.convert(
-        vcfs, out_path, show_progress=True, worker_processes=worker_processes
-    )
+    vcf.convert(vcfs, out_path, show_progress=True, worker_processes=worker_processes)
 
 
 @click.command
 @click.argument("vcfs", nargs=-1, required=True)
 @click.argument("out_path", type=click.Path())
 def validate(vcfs, out_path):
+    # FIXME! Will silently not look at remaining VCFs
     vcf.validate(vcfs[0], out_path, show_progress=True)
 
 

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -35,6 +35,9 @@ def setup_logging(verbosity):
 @worker_processes
 @click.option("-c", "--column-chunk-size", type=int, default=64)
 def explode(vcfs, out_path, verbose, worker_processes, column_chunk_size):
+    """
+    Convert VCF(s) to columnar intermediate format
+    """
     setup_logging(verbose)
     vcf.explode(
         vcfs,
@@ -49,6 +52,9 @@ def explode(vcfs, out_path, verbose, worker_processes, column_chunk_size):
 @click.argument("if_path", type=click.Path())
 @verbose
 def inspect(if_path, verbose):
+    """
+    Inspect an intermediate format file
+    """
     setup_logging(verbose)
     data = vcf.inspect(if_path)
     click.echo(tabulate.tabulate(data, headers="keys"))
@@ -57,6 +63,9 @@ def inspect(if_path, verbose):
 @click.command
 @click.argument("if_path", type=click.Path())
 def mkschema(if_path):
+    """
+    Generate a schema for zarr encoding
+    """
     stream = click.get_text_stream("stdout")
     vcf.mkschema(if_path, stream)
 
@@ -68,6 +77,9 @@ def mkschema(if_path):
 @click.option("-s", "--schema", default=None)
 @worker_processes
 def encode(if_path, zarr_path, verbose, schema, worker_processes):
+    """
+    Encode intermediate format (see explode) to vcfzarr
+    """
     setup_logging(verbose)
     vcf.encode(
         if_path,
@@ -84,6 +96,9 @@ def encode(if_path, zarr_path, verbose, schema, worker_processes):
 @verbose
 @worker_processes
 def convert_vcf(vcfs, out_path, verbose, worker_processes):
+    """
+    Convert input VCF(s) directly to vcfzarr (not recommended for large files)
+    """
     setup_logging(verbose)
     vcf.convert(vcfs, out_path, show_progress=True, worker_processes=worker_processes)
 
@@ -101,6 +116,7 @@ def vcf2zarr():
     pass
 
 
+# TODO figure out how to get click to list these in the given order.
 vcf2zarr.add_command(explode)
 vcf2zarr.add_command(inspect)
 vcf2zarr.add_command(mkschema)
@@ -116,6 +132,9 @@ vcf2zarr.add_command(validate)
 @click.option("--chunk-width", type=int, default=None)
 @click.option("--chunk-length", type=int, default=None)
 def convert_plink(in_path, out_path, worker_processes, chunk_width, chunk_length):
+    """
+    In development; DO NOT USE!
+    """
     plink.convert(
         in_path,
         out_path,

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -56,10 +56,9 @@ def inspect(if_path, verbose):
 
 @click.command
 @click.argument("if_path", type=click.Path())
-# @click.argument("specfile", type=click.Path())
-def genspec(if_path):
+def mkschema(if_path):
     stream = click.get_text_stream("stdout")
-    vcf.generate_spec(if_path, stream)
+    vcf.mkschema(if_path, stream)
 
 
 @click.command
@@ -105,7 +104,7 @@ def vcf2zarr():
 
 vcf2zarr.add_command(explode)
 vcf2zarr.add_command(inspect)
-vcf2zarr.add_command(genspec)
+vcf2zarr.add_command(mkschema)
 vcf2zarr.add_command(to_zarr)
 vcf2zarr.add_command(convert_vcf)
 vcf2zarr.add_command(validate)

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -85,7 +85,7 @@ def encode(if_path, zarr_path, verbose, schema, worker_processes):
 @worker_processes
 def convert_vcf(vcfs, out_path, verbose, worker_processes):
     setup_logging(verbose)
-    vcf.convert_vcf(
+    vcf.convert(
         vcfs, out_path, show_progress=True, worker_processes=worker_processes
     )
 

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -65,14 +65,14 @@ def mkschema(if_path):
 @click.argument("if_path", type=click.Path())
 @click.argument("zarr_path", type=click.Path())
 @verbose
-@click.option("-s", "--conversion-spec", default=None)
+@click.option("-s", "--schema", default=None)
 @worker_processes
-def to_zarr(if_path, zarr_path, verbose, conversion_spec, worker_processes):
+def encode(if_path, zarr_path, verbose, schema, worker_processes):
     setup_logging(verbose)
-    vcf.to_zarr(
+    vcf.encode(
         if_path,
         zarr_path,
-        conversion_spec,
+        schema,
         worker_processes=worker_processes,
         show_progress=True,
     )
@@ -105,7 +105,7 @@ def vcf2zarr():
 vcf2zarr.add_command(explode)
 vcf2zarr.add_command(inspect)
 vcf2zarr.add_command(mkschema)
-vcf2zarr.add_command(to_zarr)
+vcf2zarr.add_command(encode)
 vcf2zarr.add_command(convert_vcf)
 vcf2zarr.add_command(validate)
 

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -48,9 +48,9 @@ def explode(vcfs, out_path, verbose, worker_processes, column_chunk_size):
 @click.command
 @click.argument("columnarised", type=click.Path())
 @verbose
-def summarise(columnarised, verbose):
+def inspect(columnarised, verbose):
     setup_logging(verbose)
-    data = vcf.summarise(columnarised)
+    data = vcf.inspect(columnarised)
     click.echo(tabulate.tabulate(data, headers="keys"))
 
 
@@ -104,7 +104,7 @@ def vcf2zarr():
 
 
 vcf2zarr.add_command(explode)
-vcf2zarr.add_command(summarise)
+vcf2zarr.add_command(inspect)
 vcf2zarr.add_command(genspec)
 vcf2zarr.add_command(to_zarr)
 vcf2zarr.add_command(convert_vcf)

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -879,9 +879,9 @@ def explode(
     )
 
 
-def inspect(columnarised):
+def inspect(if_path):
     # TODO add support for the Zarr format also
-    pcvcf = PickleChunkedVcf.load(columnarised)
+    pcvcf = PickleChunkedVcf.load(if_path)
     return pcvcf.summary_table()
 
 
@@ -1309,16 +1309,16 @@ class SgvcfZarr:
         os.rename(write_path, path)
 
 
-def generate_spec(columnarised, out):
-    pcvcf = PickleChunkedVcf.load(columnarised)
+def generate_spec(if_path, out):
+    pcvcf = PickleChunkedVcf.load(if_path)
     spec = ZarrConversionSpec.generate(pcvcf)
     json.dump(spec.asdict(), out, indent=4)
 
 
 def to_zarr(
-    columnarised, zarr_path, conversion_spec, worker_processes=1, show_progress=False
+    if_path, zarr_path, conversion_spec, worker_processes=1, show_progress=False
 ):
-    pcvcf = PickleChunkedVcf.load(columnarised)
+    pcvcf = PickleChunkedVcf.load(if_path)
     if conversion_spec is None:
         spec = ZarrConversionSpec.generate(pcvcf)
     else:

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -1326,19 +1326,19 @@ def mkschema(if_path, out):
     out.write(spec.asjson())
 
 
-def to_zarr(
-    if_path, zarr_path, conversion_spec, worker_processes=1, show_progress=False
+def encode(
+    if_path, zarr_path, schema_path, worker_processes=1, show_progress=False
 ):
     pcvcf = PickleChunkedVcf.load(if_path)
-    if conversion_spec is None:
-        spec = ZarrConversionSpec.generate(pcvcf)
+    if schema_path is None:
+        schema = ZarrConversionSpec.generate(pcvcf)
     else:
-        with open(conversion_spec, "r") as f:
-            spec = ZarrConversionSpec.fromjson(f.read())
+        with open(schema_path, "r") as f:
+            schema = ZarrConversionSpec.fromjson(f.read())
     SgvcfZarr.convert(
         pcvcf,
         zarr_path,
-        conversion_spec=spec,
+        conversion_spec=schema,
         worker_processes=worker_processes,
         show_progress=show_progress,
     )

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -879,8 +879,9 @@ def explode(
     )
 
 
-def summarise(columnarised):
-    pcvcf = vcf.PickleChunkedVcf.load(columnarised)
+def inspect(columnarised):
+    # TODO add support for the Zarr format also
+    pcvcf = PickleChunkedVcf.load(columnarised)
     return pcvcf.summary_table()
 
 

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -923,7 +923,9 @@ class ZarrConversionSpec:
     @staticmethod
     def fromdict(d):
         ret = ZarrConversionSpec(**d)
-        ret.columns = {key: ZarrColumnSpec(**value) for key,value in d["columns"].items()}
+        ret.columns = {
+            key: ZarrColumnSpec(**value) for key, value in d["columns"].items()
+        }
         return ret
 
     @staticmethod
@@ -1326,9 +1328,7 @@ def mkschema(if_path, out):
     out.write(spec.asjson())
 
 
-def encode(
-    if_path, zarr_path, schema_path, worker_processes=1, show_progress=False
-):
+def encode(if_path, zarr_path, schema_path, worker_processes=1, show_progress=False):
     pcvcf = PickleChunkedVcf.load(if_path)
     if schema_path is None:
         schema = ZarrConversionSpec.generate(pcvcf)

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -1344,7 +1344,7 @@ def encode(
     )
 
 
-def convert_vcf(
+def convert(
     vcfs,
     out_path,
     *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,3 +47,20 @@ class TestWithMocks:
             # the CliRunner
             # mocked.assert_called_once_with("path", stdout)
             mocked.assert_called_once()
+
+    def test_encode(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        with mock.patch("bio2zarr.vcf.encode") as mocked:
+            result = runner.invoke(
+                cli.vcf2zarr, ["encode", "if_path", "zarr_path"], catch_exceptions=False
+            )
+            assert result.exit_code == 0
+            assert len(result.stdout) == 0
+            assert len(result.stderr) == 0
+            mocked.assert_called_once_with(
+                "if_path",
+                "zarr_path",
+                None,
+                worker_processes=1,
+                show_progress=True,
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,3 +64,19 @@ class TestWithMocks:
                 worker_processes=1,
                 show_progress=True,
             )
+
+    def test_convert(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        with mock.patch("bio2zarr.vcf.convert") as mocked:
+            result = runner.invoke(
+                cli.vcf2zarr, ["convert", "vcf_path", "zarr_path"], catch_exceptions=False
+            )
+            assert result.exit_code == 0
+            assert len(result.stdout) == 0
+            assert len(result.stderr) == 0
+            mocked.assert_called_once_with(
+                ("vcf_path",),
+                "zarr_path",
+                worker_processes=1,
+                show_progress=True,
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,3 +33,17 @@ class TestWithMocks:
             assert result.stdout == "\n"
             assert len(result.stderr) == 0
             mocked.assert_called_once_with("path")
+
+    def test_mkschema(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        with mock.patch("bio2zarr.vcf.mkschema") as mocked:
+            result = runner.invoke(
+                cli.vcf2zarr, ["mkschema", "path"], catch_exceptions=False
+            )
+            assert result.exit_code == 0
+            assert len(result.stdout) == 0
+            assert len(result.stderr) == 0
+            # TODO figure out how to test that we call it with stdout from
+            # the CliRunner
+            # mocked.assert_called_once_with("path", stdout)
+            mocked.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,11 +65,13 @@ class TestWithMocks:
                 show_progress=True,
             )
 
-    def test_convert(self):
+    def test_convert_vcf(self):
         runner = ct.CliRunner(mix_stderr=False)
         with mock.patch("bio2zarr.vcf.convert") as mocked:
             result = runner.invoke(
-                cli.vcf2zarr, ["convert", "vcf_path", "zarr_path"], catch_exceptions=False
+                cli.vcf2zarr,
+                ["convert", "vcf_path", "zarr_path"],
+                catch_exceptions=False,
             )
             assert result.exit_code == 0
             assert len(result.stdout) == 0
@@ -78,5 +80,40 @@ class TestWithMocks:
                 ("vcf_path",),
                 "zarr_path",
                 worker_processes=1,
+                show_progress=True,
+            )
+
+    def test_validate(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        with mock.patch("bio2zarr.vcf.validate") as mocked:
+            result = runner.invoke(
+                cli.vcf2zarr,
+                ["validate", "vcf_path", "zarr_path"],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 0
+            assert len(result.stdout) == 0
+            assert len(result.stderr) == 0
+            mocked.assert_called_once_with(
+                "vcf_path",
+                "zarr_path",
+                show_progress=True,
+            )
+
+    def test_convert_plink(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        with mock.patch("bio2zarr.plink.convert") as mocked:
+            result = runner.invoke(
+                cli.plink2zarr, ["convert", "in", "out"], catch_exceptions=False
+            )
+            assert result.exit_code == 0
+            assert len(result.stdout) == 0
+            assert len(result.stderr) == 0
+            mocked.assert_called_once_with(
+                "in",
+                "out",
+                worker_processes=1,
+                chunk_width=None,
+                chunk_length=None,
                 show_progress=True,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,14 +4,13 @@ import click.testing as ct
 
 from bio2zarr import cli
 
-class TestWithMocks:
 
+class TestWithMocks:
     def test_vcf_explode(self):
         runner = ct.CliRunner(mix_stderr=False)
         with mock.patch("bio2zarr.vcf.explode") as mocked:
             result = runner.invoke(
                 cli.vcf2zarr, ["explode", "source", "dest"], catch_exceptions=False
-
             )
             assert result.exit_code == 0
             assert len(result.stdout) == 0
@@ -24,15 +23,13 @@ class TestWithMocks:
                 show_progress=True,
             )
 
-    def test_summarise(self):
+    def test_inspect(self):
         runner = ct.CliRunner(mix_stderr=False)
-        with mock.patch("bio2zarr.vcf.summarise", return_value={}) as mocked:
+        with mock.patch("bio2zarr.vcf.inspect", return_value={}) as mocked:
             result = runner.invoke(
-                cli.vcf2zarr, ["summarise", "path"], catch_exceptions=False
-
+                cli.vcf2zarr, ["inspect", "path"], catch_exceptions=False
             )
             assert result.exit_code == 0
             assert result.stdout == "\n"
             assert len(result.stderr) == 0
             mocked.assert_called_once_with("path")
-

--- a/tests/test_pcvcf.py
+++ b/tests/test_pcvcf.py
@@ -27,6 +27,9 @@ class TestSmallExample:
         cols = [d["name"] for d in data]
         assert sorted(cols) == self.columns
 
+    def test_inspect(self, pcvcf):
+        assert pcvcf.summary_table() == vcf.inspect(pcvcf.path)
+
     def test_mapping_methods(self, pcvcf):
         assert len(pcvcf) == len(self.columns)
         assert pcvcf["ALT"] is pcvcf.columns["ALT"]

--- a/tests/test_pcvcf.py
+++ b/tests/test_pcvcf.py
@@ -22,6 +22,15 @@ class TestSmallExample:
         out = tmp_path_factory.mktemp("data") / "example.exploded"
         return vcf.explode([self.data_path], out)
 
+    def test_mkschema(self, tmp_path, pcvcf):
+        schema_file = tmp_path / "schema.json"
+        with open(schema_file, "w") as f:
+            vcf.mkschema(pcvcf.path, f)
+        with open(schema_file, "r") as f:
+            schema1 = vcf.ZarrConversionSpec.fromjson(f.read())
+        schema2 = vcf.ZarrConversionSpec.generate(pcvcf)
+        assert schema1 == schema2
+
     def test_summary_table(self, pcvcf):
         data = pcvcf.summary_table()
         cols = [d["name"] for d in data]
@@ -110,8 +119,7 @@ class TestGeneratedFieldsExample:
         ],
     )
     def test_info_schemas(self, schema, name, dtype, shape):
-        variables = [v for v in schema.variables if v.name == name]
-        v = variables[0]
+        v = schema.columns[name]
         assert v.dtype == dtype
         assert tuple(v.shape) == shape
 

--- a/tests/test_simulated_data.py
+++ b/tests/test_simulated_data.py
@@ -28,7 +28,7 @@ class TestTskitRoundTripVcf:
         # This also compresses the input file
         pysam.tabix_index(str(vcf_file), preset="vcf")
         out = tmp_path / "example.vcf.zarr"
-        vcf.convert_vcf([tmp_path / "sim.vcf.gz"], out)
+        vcf.convert([tmp_path / "sim.vcf.gz"], out)
         ds = sg.load_dataset(out)
         assert ds.sizes["ploidy"] == ploidy
         assert ds.sizes["variants"] == ts.num_sites

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -13,7 +13,7 @@ class TestSmallExample:
     @pytest.fixture(scope="class")
     def ds(self, tmp_path_factory):
         out = tmp_path_factory.mktemp("data") / "example.vcf.zarr"
-        vcf.convert_vcf([self.data_path], out)
+        vcf.convert([self.data_path], out)
         return sg.load_dataset(out)
 
     def test_filters(self, ds):
@@ -224,7 +224,7 @@ class TestSmallExample:
     def test_no_genotypes(self, ds, tmp_path):
         path = "tests/data/vcf/sample_no_genotypes.vcf.gz"
         out = tmp_path / "example.vcf.zarr"
-        vcf.convert_vcf([path], out)
+        vcf.convert([path], out)
         ds2 = sg.load_dataset(out)
         assert len(ds2["sample_id"]) == 0
         for col in ds:
@@ -244,7 +244,7 @@ class TestSmallExample:
         self, ds, tmp_path, chunk_length, chunk_width, y_chunks, x_chunks
     ):
         out = tmp_path / "example.vcf.zarr"
-        vcf.convert_vcf(
+        vcf.convert(
             [self.data_path], out, chunk_length=chunk_length, chunk_width=chunk_width
         )
         ds2 = sg.load_dataset(out)
@@ -277,7 +277,7 @@ class TestSmallExample:
     @pytest.mark.parametrize("worker_processes", [0, 1, 2])
     def test_worker_processes(self, ds, tmp_path, worker_processes):
         out = tmp_path / "example.vcf.zarr"
-        vcf.convert_vcf(
+        vcf.convert(
             [self.data_path], out, chunk_length=3, worker_processes=worker_processes
         )
         ds2 = sg.load_dataset(out)
@@ -306,7 +306,7 @@ class Test1000G2020Example:
     @pytest.fixture(scope="class")
     def ds(self, tmp_path_factory):
         out = tmp_path_factory.mktemp("data") / "example.vcf.zarr"
-        vcf.convert_vcf([self.data_path], out, worker_processes=0)
+        vcf.convert([self.data_path], out, worker_processes=0)
         return sg.load_dataset(out)
 
     def test_position(self, ds):
@@ -418,7 +418,7 @@ class Test1000G2020AnnotationsExample:
     def ds(self, tmp_path_factory):
         out = tmp_path_factory.mktemp("data") / "example.zarr"
         # TODO capture warnings from htslib here
-        vcf.convert_vcf([self.data_path], out, worker_processes=0)
+        vcf.convert([self.data_path], out, worker_processes=0)
         return sg.load_dataset(out)
 
     def test_position(self, ds):
@@ -650,7 +650,7 @@ class TestGeneratedFieldsExample:
     @pytest.fixture(scope="class")
     def ds(self, tmp_path_factory):
         out = tmp_path_factory.mktemp("data") / "vcf.zarr"
-        vcf.convert_vcf([self.data_path], out)
+        vcf.convert([self.data_path], out)
         return sg.load_dataset(out)
 
     def test_info_string1(self, ds):
@@ -700,5 +700,5 @@ class TestGeneratedFieldsExample:
 def test_by_validating(name, tmp_path):
     path = f"tests/data/vcf/{name}"
     out = tmp_path / "test.zarr"
-    vcf.convert_vcf([path], out, worker_processes=0)
+    vcf.convert([path], out, worker_processes=0)
     vcf.validate(path, out)

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -295,7 +295,7 @@ class TestSmallExample:
         with open(schema, "w") as f:
             vcf.mkschema(exploded, f)
         out = tmp_path / "example.zarr"
-        vcf.to_zarr(exploded, out, schema, worker_processes=worker_processes)
+        vcf.encode(exploded, out, schema, worker_processes=worker_processes)
         ds2 = sg.load_dataset(out)
         xt.assert_equal(ds, ds2)
 

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -293,7 +293,7 @@ class TestSmallExample:
         )
         schema = tmp_path / "schema.json"
         with open(schema, "w") as f:
-            vcf.generate_spec(exploded, f)
+            vcf.mkschema(exploded, f)
         out = tmp_path / "example.zarr"
         vcf.to_zarr(exploded, out, schema, worker_processes=worker_processes)
         ds2 = sg.load_dataset(out)


### PR DESCRIPTION
Closes #8

Now have:
```
Usage: python -m bio2zarr vcf2zarr [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  convert   Convert input VCF(s) directly to vcfzarr (not recommended for...
  encode    Encode intermediate format (see explode) to vcfzarr
  explode   Convert VCF(s) to columnar intermediate format
  inspect   Inspect an intermediate format file
  mkschema  Generate a schema for zarr encoding
  validate
```